### PR TITLE
Add structured chat model

### DIFF
--- a/mock_ai/models/standard_registry.py
+++ b/mock_ai/models/standard_registry.py
@@ -5,6 +5,7 @@ from .standard_chat import StandardChatModel
 from .standard_embedding import StandardEmbeddingModel
 from .standard_image import StandardImageModel
 from .standard_speech import StandardSpeechModel
+from .structured_chat import StructuredChatModel
 
 STANDARD_REGISTRY = ModelRegistry()
 
@@ -14,3 +15,4 @@ STANDARD_REGISTRY.register(StandardImageModel("mock-image-model"))
 STANDARD_REGISTRY.register(StandardSpeechModel("mock-speech-model"))
 STANDARD_REGISTRY.register(MarkdownChatModel())
 STANDARD_REGISTRY.register(ParrotChatModel())
+STANDARD_REGISTRY.register(StructuredChatModel())

--- a/mock_ai/models/structured_chat.py
+++ b/mock_ai/models/structured_chat.py
@@ -1,0 +1,125 @@
+import json
+import random
+import string
+import time
+from collections.abc import Generator, Iterator
+from typing import Any, Literal, overload
+
+from mock_ai.schemas.chat_completion_request import ModelSettings
+from mock_ai.schemas.completion_response import (
+    ChatCompletionResponse,
+    Delta,
+    DeltaChoice,
+    Message,
+    MessageChoice,
+    Usage,
+)
+from mock_ai.schemas.models_response import ModelInfo
+
+from .chat_model import ChatModel
+
+
+def _random_string(length: int = 8) -> str:
+    return "".join(random.choice(string.ascii_letters) for _ in range(length))
+
+
+def _from_schema(schema: dict) -> Any:
+    type_ = schema.get("type")
+    if type_ == "object":
+        return {
+            key: _from_schema(sub)
+            for key, sub in schema.get("properties", {}).items()
+        }
+    if type_ == "array":
+        return [_from_schema(schema.get("items", {}))]
+    if type_ == "integer":
+        return random.randint(0, 100)
+    if type_ == "number":
+        return random.random() * 100
+    if type_ == "boolean":
+        return random.choice([True, False])
+    return _random_string()
+
+
+class StructuredChatModel(ChatModel):
+    """Chat model that returns JSON according to ``response_format``."""
+
+    def __init__(self, key: str = "structured-chat-model") -> None:
+        self._key = key
+
+    @property
+    def key(self) -> str:  # pragma: no cover - simple accessor
+        return self._key
+
+    @overload
+    def get_response(
+        self,
+        model_settings: ModelSettings,
+        stream: Literal[False],
+    ) -> ChatCompletionResponse[MessageChoice]: ...
+
+    @overload
+    def get_response(
+        self,
+        model_settings: ModelSettings,
+        stream: Literal[True],
+    ) -> Iterator[ChatCompletionResponse[DeltaChoice]]: ...
+
+    def get_response(
+        self,
+        model_settings: ModelSettings,
+        stream: bool,
+    ) -> ChatCompletionResponse | Iterator[ChatCompletionResponse[DeltaChoice]]:
+        fmt = model_settings.response_format or {}
+        if fmt.get("type") == "json_schema":
+            payload = _from_schema(fmt.get("json_schema", {}))
+        else:
+            payload = {"mock": _random_string(4)}
+
+        content = json.dumps(payload)
+
+        if stream:
+
+            def stream_response() -> Generator[
+                ChatCompletionResponse[DeltaChoice], Any, None
+            ]:
+                for i in range(0, len(content), 10):
+                    time.sleep(0.01)
+                    yield ChatCompletionResponse(
+                        model=self.key,
+                        choices=[
+                            DeltaChoice(
+                                delta=Delta(content=content[i : i + 10])
+                            )
+                        ],
+                    )
+                if model_settings.needs_usage():
+                    prompt_tokens = len(str(model_settings.messages)) // 4
+                    completion_tokens = len(content) // 4
+                    yield ChatCompletionResponse(
+                        model=self.key,
+                        choices=[],
+                        usage=Usage(
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion_tokens,
+                        ),
+                    )
+
+            return stream_response()
+
+        return ChatCompletionResponse(
+            model=self.key,
+            choices=[
+                MessageChoice(
+                    index=0,
+                    message=Message(role="assistant", content=content),
+                )
+            ],
+            usage=Usage(
+                prompt_tokens=len(str(model_settings.messages)) // 4,
+                completion_tokens=len(content) // 4,
+            ),
+        )
+
+    def _get_model_info(self) -> ModelInfo:
+        return ModelInfo(id="", created=0, owned_by="")

--- a/mock_ai/schemas/chat_completion_request.py
+++ b/mock_ai/schemas/chat_completion_request.py
@@ -6,6 +6,7 @@ class ModelSettings(BaseModel):
     max_completion_tokens: int | None = None
     max_tokens: int | None = None
     temperature: float | None = 1
+    response_format: dict | None = None
     stream_options: dict | None = None
 
     def needs_usage(self) -> bool:

--- a/tests/test_structured_chat_model.py
+++ b/tests/test_structured_chat_model.py
@@ -1,0 +1,42 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.modules.pop("mock_ai", None)
+sys.modules.pop("mock_ai.models", None)
+sys.modules.pop("mock_ai.schemas", None)
+sys.modules.pop("mock_ai.schemas.chat_completion_request", None)
+
+from mock_ai.models.structured_chat import StructuredChatModel  # noqa: E402
+from mock_ai.schemas.chat_completion_request import ModelSettings  # noqa: E402
+
+
+def test_structured_chat_json_object():
+    model = StructuredChatModel()
+    settings = ModelSettings(
+        messages=[{"role": "user", "content": "ciao"}],
+        response_format={"type": "json_object"},
+    )
+    resp = model.get_response(settings, False)
+    data = json.loads(resp.choices[0].message.content)
+    assert isinstance(data, dict)
+
+
+def test_structured_chat_json_schema_stream():
+    model = StructuredChatModel()
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+    }
+    settings = ModelSettings(
+        messages=[{"role": "user", "content": "foo"}],
+        response_format={"type": "json_schema", "json_schema": schema},
+    )
+    chunks = list(model.get_response(settings, True))
+    content = "".join(c.choices[0].delta.content or "" for c in chunks)
+    data = json.loads(content)
+    assert set(data.keys()) == {"name", "age"}


### PR DESCRIPTION
## Summary
- implement a `StructuredChatModel` supporting JSON outputs
- register the new model in the standard registry
- add `response_format` field to chat request schemas
- test structured chat responses

## Testing
- `ruff check --quiet .`
- `pytest -q`
